### PR TITLE
changement de routes après scan du ticket

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
     if @product_in_db
       @item.update(product_id: @product_in_db.id)
 
-        redirect_to ticket_items_path(@ticket)
+        redirect_to ticket_path(@ticket)
     else
       # call API open food fact avec le code bar
       url = "https://world.openfoodfacts.org/api/v0/product/#{params[:bar_code]}.json"
@@ -53,7 +53,7 @@ class ItemsController < ApplicationController
           )
         # attribution de l'id du nouveau produit à l'item
         @item.update(product_id: @new_product.id)
-        redirect_to ticket_items_path(@ticket)
+        redirect_to ticket_path(@ticket)
       else
         render :edit
       end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,10 +5,8 @@ class ItemsController < ApplicationController
 
   def index
     @ticket = Ticket.find(params[:ticket_id])
-    @unidentified_items = @ticket.items.where(product_id: nil)
     authorize @ticket, :ticket_items?
   end
-
 
   def show
     @ticket = Ticket.find(params[:ticket_id])

--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -33,7 +33,7 @@ class TicketsController < ApplicationController
         TicketLine.create(ticket_id: @ticket.id, item_id: new_item.id, quantity: 1)
       end
     end
-    redirect_to ticket_items_path(@ticket)
+    redirect_to ticket_path(@ticket)
   end
 
   def destroy

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -29,9 +29,8 @@
   <% end %>
 
   <% @unidentified_items = @ticket.items.where(product_id: nil) %>
-  <% if !@unidentified_items.nil?  %>
+  <% unless @unidentified_items.empty?  %>
     <h1> Ces produits n'ont pas été identifiés </h1>
-
     <div class="container">
       <ul>
         <% @unidentified_items.each do |item| %>

--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -1,30 +1,46 @@
 <div class="container">
-<h1 id="title"><%= @title %></h1>
-<p><small>Scanné le <%= @ticket.created_at.strftime("%d/%m/%Y à %k:%M") %></small></p>
+  <h1 id="title"><%= @title %></h1>
+  <p><small>Scanné le <%= @ticket.created_at.strftime("%d/%m/%Y à %k:%M") %></small></p>
 
-<div class="ticket-icon">
-  <%= link_to ticket_path(@ticket), method: :delete, data: { confirm: "Etes vous sur de vouloir supprimer ce ticket ?" } do %>
-  <i class="far fa-trash-alt"></i>
-  <% end %>
-</div>
-<hr>
+  <div class="ticket-icon">
+    <%= link_to ticket_path(@ticket), method: :delete, data: { confirm: "Etes vous sur de vouloir supprimer ce ticket ?" } do %>
+    <i class="far fa-trash-alt"></i>
+    <% end %>
+  </div>
+  <hr>
 
-<% @ticket.items.each do |item| %>
-  <% if  item.product_id?%>
-    <%= link_to product_path(item.product_id) do %>
-      <div class="ticket-line">
-        <%= image_tag Product.find(item.product_id).photo, class: "product-img-ticket" %>
-        <div class="ticket-line-info">
-          <% if item.product_id %>
-          <p class="product-name"><%= Product.find(item.product_id).name%></p>
-          <p class="product-brand"><%= Product.find(item.product_id).brand %></p>
-            <p><span class="badge badge-pill badge-warning">Moyen</span></p>
-          <% else %>
-          <% end %>
+  <% @ticket.items.each do |item| %>
+    <% if  item.product_id?%>
+      <%= link_to product_path(item.product_id) do %>
+        <div class="ticket-line">
+          <%= image_tag Product.find(item.product_id).photo, class: "product-img-ticket" %>
+          <div class="ticket-line-info">
+            <% if item.product_id %>
+            <p class="product-name"><%= Product.find(item.product_id).name%></p>
+            <p class="product-brand"><%= Product.find(item.product_id).brand %></p>
+              <p><span class="badge badge-pill badge-warning">Moyen</span></p>
+            <% else %>
+            <% end %>
+          </div>
+          <i class="fas fa-chevron-right"></i>
         </div>
-        <i class="fas fa-chevron-right"></i>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
+
+  <% @unidentified_items = @ticket.items.where(product_id: nil) %>
+  <% if !@unidentified_items.nil?  %>
+    <h1> Ces produits n'ont pas été identifiés </h1>
+
+    <div class="container">
+      <ul>
+        <% @unidentified_items.each do |item| %>
+          <li>
+            <%= item.description %> <!-- Ici il faut recuperer les params d'un ticket et les passer dans le lien -->
+            <%= link_to "Scanner le code barre", edit_item_path(item, ticket_id: @ticket.id) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
on arrive sur toute la liste des produits après la création d'un ticket, avec en bas la liste des objets non identifiés
pour chacun d'entre eux un lien redirige directement vers le scanner.
je viens de voir que le scanner ne marchait plus, je répare ça..