### PR TITLE
Frontimages

### DIFF
--- a/app/assets/stylesheets/components/_ticket-line.scss
+++ b/app/assets/stylesheets/components/_ticket-line.scss
@@ -38,8 +38,8 @@
   text-align: center;
 }
 .img-ticket{
-  height: 50px;
-  width: auto;
+  max-height: 50px;
+  max-width: 50px;
 }
 
 .ticket-line-unidentified {

--- a/app/assets/stylesheets/components/_ticket-line.scss
+++ b/app/assets/stylesheets/components/_ticket-line.scss
@@ -35,7 +35,9 @@
   height: 50px;
   width: 50px;
   border-radius: 5%;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 .img-ticket{
   max-height: 50px;


### PR DESCRIPTION
pour info, max-height 50px et max-width 50px pour que ça fit dans tous les cas au lieu de width auto et height 50px

![Capture d’écran 2020-11-30 à 10 20 10](https://user-images.githubusercontent.com/69197574/100591176-add92e80-32f5-11eb-83b1-afb4cd6e4b81.png)
