### PR TITLE
new display fav, amélioration récup image dans api

### DIFF
--- a/app/assets/stylesheets/components/_gallery.scss
+++ b/app/assets/stylesheets/components/_gallery.scss
@@ -1,10 +1,10 @@
 .gallery-container {
-  column-count: 2;
+  column-count: 3;
   column-gap: 0.5rem;
   row-gap: 0.5rem;
 }
 .gallery-item {
-  display: inline-block;
+  display: block;
   margin: 0;
   width: 100%;
   overflow: hidden;
@@ -12,7 +12,6 @@
   position: relative;
   margin-bottom: 0.5rem;
 	border-bottom: none;
-  background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.3));
   img {
     width: 100%;
     height: auto;
@@ -28,5 +27,8 @@
     top: 0.2rem;
     right: 0.2rem;
     color: white;
+    background-color: $gray;
+    padding: 0.2rem 0.3rem;
+    border-radius: 50%;
   }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ class ItemsController < ApplicationController
           bar_code: params[:bar_code],
           category: product["product"]["categories_tags"].first,
           name: product["product"]["product_name_fr"],
-          photo: product["product"]["selected_images"]["front"]["small"]["fr"],
+          photo: product["product"]["selected_images"]["front"]["small"].first[1],
           generic_name: product["product"]["generic_name"],
           brand: product["product"]["brands"],
           category_agribalyse: product["product"]["categories_properties"]["agribalyse_food_code:en"]

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -9,7 +9,7 @@
 
   <div class="gallery-container">
     <% if @favorites.count != 0 %>
-      <% @favorites.each do |favorite| %>
+      <% @favorites.reverse.each do |favorite| %>
         <div class="gallery-item">
           <%= link_to product_path(favorite.product) do %>
             <%= image_tag favorite.product.photo %>


### PR DESCRIPTION
### Display fav
- 3 colonnes
- corbeille sur fond gris
=> reste à faire : si image trop grande (comme le dentifrice, à voir si on peut automatiser une rotation à 90°)
![image](https://user-images.githubusercontent.com/25443871/100592872-f98cd780-32f7-11eb-99e8-1244682988d4.png)

### Bug import image
en ajoutant un produit qui n'était pas fnraçais, je me suis rendu compte que le code posait problème, car nous importions les image avec le tag "fr". Désormais, on importe la première image disponible, quelque soit la langue.