### PR TITLE
affichage des produits non identifiés en haut de la liste

### DIFF
--- a/app/views/tickets/show.html.erb
+++ b/app/views/tickets/show.html.erb
@@ -8,6 +8,19 @@
     <% end %>
   </div>
 
+ <% unless @unidentified_items.empty?  %>
+
+    <p><strong>Ces produits n'ont pas été identifiés</strong></p>
+    <% @unidentified_items.each do |item| %>
+      <div class="ticket-line ticket-line-unidentified">
+        <%= item.description %> <!-- Ici il faut recuperer les params d'un ticket et les passer dans le lien -->
+        <%= link_to edit_item_path(item, ticket_id: @ticket.id) do %>
+          <i class="fas fa-camera"></i>
+
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
   <% @ticket.items.each do |item| %>
     <% if  item.product_id?%>
       <%= link_to product_path(item.product_id) do %>
@@ -26,20 +39,6 @@
           <i class="fas fa-chevron-right"></i>
         </div>
       <% end %>
-    <% end %>
-  <% end %>
-
-  <% unless @unidentified_items.empty?  %>
-
-    <p><strong>Ces produits n'ont pas été identifiés</strong></p>
-    <% @unidentified_items.each do |item| %>
-      <div class="ticket-line ticket-line-unidentified">
-        <%= item.description %> <!-- Ici il faut recuperer les params d'un ticket et les passer dans le lien -->
-        <%= link_to edit_item_path(item, ticket_id: @ticket.id) do %>
-          <i class="fas fa-camera"></i>
-
-        <% end %>
-      </div>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
suite à reco de Germain sur ce point: plus à scroller pour voir les non identifiés

![Capture d’écran 2020-11-30 à 11 22 35](https://user-images.githubusercontent.com/69197574/100597936-5a1f1300-32fe-11eb-9853-c63522d7dde3.png)
